### PR TITLE
fix!: expr mapping を使わない方針に変更

### DIFF
--- a/lua/modesearch/core.lua
+++ b/lua/modesearch/core.lua
@@ -1,5 +1,5 @@
-local state = require "modesearch.state"
-local config = require "modesearch.config"
+local state = require("modesearch.state")
+local config = require("modesearch.config")
 local M = {}
 
 ---@param text string
@@ -18,9 +18,10 @@ local function _prompt()
     local query
     vim.ui.input({
         prompt = prev_mode.prompt,
-        cancelreturn = M.exprstr "<Nul>",
+        cancelreturn = M.exprstr("<Nul>"),
     }, function(text)
         query = text
+        vim.print { t = "ui.input", text = text }
     end)
     while state.current_mode_name ~= prev_mode_name do
         prev_mode_name = state.current_mode_name
@@ -28,12 +29,13 @@ local function _prompt()
         vim.ui.input({
             prompt = prev_mode.prompt,
             default = query,
-            cancelreturn = M.exprstr "<Nul>",
+            cancelreturn = M.exprstr("<Nul>"),
         }, function(text)
             query = text
+            vim.print { t = "ui.input", text = text }
         end)
     end
-    if query == M.exprstr "<Nul>" then
+    if query == M.exprstr("<Nul>") then
         return nil
     end
     return query
@@ -42,16 +44,17 @@ end
 function M.prompt()
     state.prompt_active = true
     local query = _prompt()
+    vim.print { t = "test", query = query }
     state.prompt_active = false
     if query == nil then
         return ""
     end
     local search_cmd = "/"
     if query == "" then
-        return search_cmd .. M.exprstr "<CR>"
+        return search_cmd .. M.exprstr("<CR>")
     end
     local current_mode = config.options.modes[state.current_mode_name]
-    return search_cmd .. current_mode.converter(query) .. M.exprstr "<CR>"
+    vim.api.nvim_feedkeys(search_cmd .. current_mode.converter(query) .. M.exprstr("<CR>"), "n", false)
 end
 
 function M.highlight_paint()

--- a/lua/modesearch/init.lua
+++ b/lua/modesearch/init.lua
@@ -1,10 +1,10 @@
 local M = {}
 
-local config = require "modesearch.config"
-local core = require "modesearch.core"
-local state = require "modesearch.state"
+local config = require("modesearch.config")
+local core = require("modesearch.core")
+local state = require("modesearch.state")
 
-M.keymap = require "modesearch.keymap"
+M.keymap = require("modesearch.keymap")
 
 local augroup = vim.api.nvim_create_augroup("modesearch", {})
 

--- a/lua/modesearch/keymap.lua
+++ b/lua/modesearch/keymap.lua
@@ -1,25 +1,23 @@
 local M = {}
 
-local config = require "modesearch.config"
-local core = require "modesearch.core"
-local state = require "modesearch.state"
+local config = require("modesearch.config")
+local core = require("modesearch.core")
+local state = require("modesearch.state")
 
 M.prompt = {}
 M.mode = {}
 
 ---@param mode_name string
----@return string
 function M.prompt.show(mode_name)
     local mode = config.options.modes[mode_name]
     if mode == nil then
         error("Mode '" .. mode_name .. "' is not defined.")
     end
     state.current_mode_name = mode_name
-    return core.prompt()
+    core.prompt()
 end
 
 ---@param mode_names string[]
----@return string
 function M.mode.cycle(mode_names)
     local index = nil
     for i, name in ipairs(mode_names) do
@@ -29,7 +27,7 @@ function M.mode.cycle(mode_names)
         end
     end
     if index == nil then
-        return ""
+        return
     end
     if index >= #mode_names then
         index = index % #mode_names
@@ -39,20 +37,19 @@ function M.mode.cycle(mode_names)
         error("Mode '" .. next_mode_name .. "' is not defined.")
     end
     state.current_mode_name = next_mode_name
-    return core.exprstr "<CR>"
+    vim.api.nvim_feedkeys(core.exprstr("<CR>"), "n", false)
 end
 
 ---@param mode_name string
----@return string
 function M.mode.set(mode_name)
     if state.current_mode_name == mode_name then
-        return ""
+        return
     end
     if config.options.modes[mode_name] == nil then
         error("Mode '" .. mode_name .. "' is not defined.")
     end
     state.current_mode_name = mode_name
-    return core.exprstr "<CR>"
+    vim.api.nvim_feedkeys(core.exprstr("<CR>"), "n", false)
 end
 
 return M


### PR DESCRIPTION
blink.cmp と組み合わせると expr mapping 上での vim.ui.input がなぜか正常に動かないことがわかったため。